### PR TITLE
Fix outdated indentation syntax

### DIFF
--- a/src/main/scala/Givens.scala
+++ b/src/main/scala/Givens.scala
@@ -9,7 +9,7 @@ import io.circe.Decoder
 import io.circe.Json
 import io.circe.syntax._
 
-given Decoder[RecognizedText] 
+given Decoder[RecognizedText]:
     def apply(c: HCursor): Result[RecognizedText] = 
         for {
             text <- c.get[String]("Text")
@@ -26,7 +26,7 @@ given Decoder[RecognizedText]
             RecognizedText(text, confidence, topLeftX, topLeftY, topRightX, topRightY, bottomLeftX
             ,bottomLeftY, bottomRightX, bottomRightY)
 
-given Encoder[RecognizedText]
+given Encoder[RecognizedText]:
     def apply(rt: RecognizedText): Json = Json.obj(
         ("Text", Json.fromString(rt.text)),
         ("Confidence", Json.fromDouble(rt.confidence).get),
@@ -39,14 +39,14 @@ given Encoder[RecognizedText]
         ("BottomRightX", Json.fromInt(rt.bottomRightX)),
         ("BottomRightY", Json.fromInt(rt.bottomRightY)))
     
-given Decoder[RecognizedTexts]
+given Decoder[RecognizedTexts]:
     def apply(c: HCursor): Result[RecognizedTexts] = 
         c.get[Seq[RecognizedText]]("RecognizedText").map(RecognizedTexts)
 
-given Encoder[RecognizedTexts]
+given Encoder[RecognizedTexts]:
     def apply(rts: RecognizedTexts): Json = Json.obj(
         ("RecognizedText", rts.recognizedTexts.asJson))
-given Decoder[Page]
+given Decoder[Page]:
     def apply(c: HCursor): Result[Page] =
         for {
             error <- c.get[Option[String]]("Error")
@@ -59,7 +59,7 @@ given Decoder[Page]
             val sanitizedError = error.flatMap((e: String) => if(e.isEmpty) None else Some(e))
             Page(sanitizedError, fileIndex, pageNumber, numberOfPagesInFile, recognizedText)
 
-given Encoder[Page]
+given Encoder[Page]:
     def apply(p: Page): Json = Json.obj(
         ("Error", if(p.error.isEmpty || p.error.get.isEmpty) Json.Null else Json.fromString(p.error.get)),
         ("FileIndex", Json.fromInt(p.fileIndex)),
@@ -67,18 +67,18 @@ given Encoder[Page]
         ("NumberOfPagesInFile", Json.fromInt(p.numberOfPagesInFile)),
         ("RecognizedText", p.recognizedText.asJson))
 
-given Decoder[Pages]
+given Decoder[Pages]:
     def apply(c: HCursor): Result[Pages] = 
         c.get[Seq[Page]]("Pages").map(Pages)
 
-given Encoder[Pages]
+given Encoder[Pages]:
     def apply(ps: Pages): Json = Json.obj(
         ("Pages", ps.pages.asJson))
 
-given Decoder[PollingUrl]
+given Decoder[PollingUrl]:
     def apply(c: HCursor): Result[PollingUrl] = 
         c.get[String]("PollingURL").map(PollingUrl)
 
-given Encoder[PollingUrl]
+given Encoder[PollingUrl]:
     def apply(pu: PollingUrl): Json = Json.obj(
         ("PollingURL", Json.fromString(pu.pollingUrl)))

--- a/src/main/scala/Types.scala
+++ b/src/main/scala/Types.scala
@@ -4,7 +4,7 @@ import sight.models.Error
 import sight.models.Error._
 
 opaque type APIKey = String
-object APIKey
+object APIKey:
     def apply(apiKey: String): Either[Error,APIKey] = apiKey.split("-") match
         case Array(f, s, t, fo, fi) if (f.length == 8 && s.length == 4 && t.length == 4 && fo.length == 4 && fi.length == 12) => Right(apiKey)
         case _ => Left(InvalidAPIKeyFormat("Invalid key. Key should be of the form xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"))

--- a/src/main/scala/client/FIleContentReaderImpl.scala
+++ b/src/main/scala/client/FIleContentReaderImpl.scala
@@ -8,7 +8,7 @@ import org.apache.commons.codec.binary.Base64
 import java.nio.file.{Files, Paths}
 import scala.collection.mutable.ListBuffer
 
-class FileContentReaderImpl extends FileContentReader
+class FileContentReaderImpl extends FileContentReader:
     def filesToBase64(filePaths: Seq[String]): Either[Error, Seq[String]] = 
         val base64s = ListBuffer[String]()
         var error: Option[Error] = None

--- a/src/main/scala/client/FileContentReader.scala
+++ b/src/main/scala/client/FileContentReader.scala
@@ -3,6 +3,6 @@ package sight.client
 import sight.models.Error
 import sight.models.MimeType
 
-trait FileContentReader
+trait FileContentReader:
     def filesToBase64(filePaths: Seq[String]): Either[Error, Seq[String]]
     def fileMimeTypes(filePaths: Seq[String]): Either[Error, Seq[MimeType]]

--- a/src/main/scala/client/SightClient.scala
+++ b/src/main/scala/client/SightClient.scala
@@ -4,11 +4,11 @@ import sight.types.APIKey
 import sight.models.{Pages, Error}
 import sttp.client.{SttpBackend, HttpURLConnectionBackend, Identity, NothingT}
 
-trait SightClient(private val apiKey: APIKey, private val fileContentReader: FileContentReader)
+trait SightClient(private val apiKey: APIKey, private val fileContentReader: FileContentReader):
     def recognize(filePaths: Seq[String]): Either[Error,Pages] = recognize(filePaths, false)
     def recognize(filePaths: Seq[String], shouldWordLevelBoundBoxes: Boolean): Either[Error, Pages]
 
-object SightClient
+object SightClient:
     def apply(apiKey: APIKey): SightClient = 
         given SttpBackend[Identity, Nothing, NothingT] = HttpURLConnectionBackend()
         val fileContentReader = new FileContentReaderImpl()

--- a/src/main/scala/client/SightClientImpl.scala
+++ b/src/main/scala/client/SightClientImpl.scala
@@ -14,14 +14,14 @@ import cats.implicits.{given _}
 import scala.language.implicitConversions
 import sttp.client.{SttpBackend, Identity, NothingT}
 
-class SightClientImpl(private val apiKey: APIKey, private val fileContentReader: FileContentReader)(using SttpBackend[Identity, Nothing, NothingT]) extends SightClient(apiKey, fileContentReader)
+class SightClientImpl(private val apiKey: APIKey, private val fileContentReader: FileContentReader)(using SttpBackend[Identity, Nothing, NothingT]) extends SightClient(apiKey, fileContentReader):
     private case class FileContent(mimeType: MimeType, base64FileContent: String)
     private case class Payload(shouldMakeSentences: Boolean, files: Seq[FileContent])
-    private given Encoder[FileContent]
+    private given Encoder[FileContent]:
         def apply(fileContent: FileContent): Json = Json.obj(
             ("mimeType", Json.fromString(fileContent.mimeType.strRep)),
             ("base64File", Json.fromString(fileContent.base64FileContent)))
-    private given Encoder[Payload]
+    private given Encoder[Payload]:
         def apply(payload: Payload): Json = Json.obj(
             ("makeSentences", Json.fromBoolean(payload.shouldMakeSentences)),
             ("files", payload.files.asJson))

--- a/src/main/scala/models/Errors.scala
+++ b/src/main/scala/models/Errors.scala
@@ -1,6 +1,6 @@
 package sight.models
 
-enum Error(val msg: String)
+enum Error(val msg: String):
     case InvalidAPIKeyFormat(message: String) extends Error(message)
     case InvalidExtension(message: String) extends Error(message)
     case FileDoesNotExist(message: String) extends Error(message)

--- a/src/main/scala/models/MimeType.scala
+++ b/src/main/scala/models/MimeType.scala
@@ -1,7 +1,7 @@
 package sight.models
 import Error.InvalidExtension
 
-enum MimeType(val strRep: String)
+enum MimeType(val strRep: String):
     case GIF extends MimeType("image/gif")
     case BMP extends MimeType("image/bmp")
     case PDF extends MimeType("application/pdf")
@@ -9,7 +9,7 @@ enum MimeType(val strRep: String)
     case JPEG extends MimeType("image/jpeg")
     case PNG extends MimeType("image/png")
 
-object MimeType
+object MimeType:
     def fromExtension(ext: String): Either[Error, MimeType] = ext match
         case "gif" => Right(GIF)
         case "bmp" => Right(BMP)

--- a/src/test/scala/FileContentReaderImplTest.scala
+++ b/src/test/scala/FileContentReaderImplTest.scala
@@ -2,7 +2,7 @@ import sight.client.FileContentReaderImpl
 import sight.models.MimeType._
 import sight.models.Error.InvalidExtension
 
-class FileContentReaderImplTest extends munit.FunSuite
+class FileContentReaderImplTest extends munit.FunSuite:
     test("Should return correct mime types when valid") {
         val filePaths = Seq("foo/goo.bmp", "baz/de.gif")
         val fileContentReader = new FileContentReaderImpl()

--- a/src/test/scala/JsonTest.scala
+++ b/src/test/scala/JsonTest.scala
@@ -6,7 +6,7 @@ import munit.Location.generate
 import io.circe.parser.decode
 
 
-class JsonTest extends munit.FunSuite
+class JsonTest extends munit.FunSuite:
 
 
     import sight.givens.{given Encoder[Pages], given Decoder[Pages], given Encoder[Page]}

--- a/src/test/scala/SighClientImplTest.scala
+++ b/src/test/scala/SighClientImplTest.scala
@@ -15,7 +15,7 @@ import io.circe.{Encoder, Decoder}
 import io.circe.syntax.{given _}
 import scala.collection.mutable.ListBuffer
 
-class SightClientImplTest extends FunSuite
+class SightClientImplTest extends FunSuite:
 
     private val postArgs: ListBuffer[(String, String, String)] = ListBuffer() //Url, payload, Auth
     private val getArgs: ListBuffer[(String, String)] = ListBuffer() //url, Auth
@@ -25,9 +25,9 @@ class SightClientImplTest extends FunSuite
         getArgs.clear
 
     given SttpBackend[Identity, Nothing, NothingT] = HttpURLConnectionBackend()
-    def withSttpBackend[M](postResponse: Either[String, String], getResponse: Either[String, String]) = new SttpBackend[Identity, Nothing, NothingT] with
+    def withSttpBackend[M](postResponse: Either[String, String], getResponse: Either[String, String]) = new SttpBackend[Identity, Nothing, NothingT]:
         def send[T](request: Request[T, Nothing]): Response[T] = 
-            if(request.method == POST) 
+            if(request.method == POST)
                 val uri = request.productElement(1)
                 val body: StringBody = request.productElement(2).asInstanceOf[StringBody]
                 val payload = body.productElement(0)
@@ -47,7 +47,7 @@ class SightClientImplTest extends FunSuite
         case Left(err) => throw new Exception(s"Unexpected error $err")
 
     def fileContentReaderWith(fileToBase64: Either[Error, Seq[String]], fileMimeType: Either[Error, Seq[MimeType]]) = 
-        new FileContentReader with
+        new FileContentReader:
             def filesToBase64(filePaths: Seq[String]): Either[Error, Seq[String]] = fileToBase64
             def fileMimeTypes(filePaths: Seq[String]): Either[Error, Seq[MimeType]] = fileMimeType
 


### PR DESCRIPTION
A class/object needs a `:` to define a body with indentation, this will
be enforced in the next Dotty release.